### PR TITLE
Upgrade to nom 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.0.1"
 authors = ["Elijah Charles <elijah.charles@intel.com>"]
 
 [dependencies]
-nom = "0.3.0"
+nom = "~1.0.0"

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,6 +1,5 @@
 use std::str;
-use nom::IResult::*;
-use nom::{IResult,Needed,not_line_ending,line_ending,eof};
+use nom::{IResult,not_line_ending,line_ending,eof};
 
 #[derive(Debug)]
 pub struct Base {


### PR DESCRIPTION
Hi!

nom 1.0 is here, and comes with a few breaking changes. To help the transition, and to test the beta version before release, I took the liberty to test and upgrade (if needed) your code to the 1.0 version. It should work right away, but if there are still issues, or if the code needs to be updated to your latest master, please let me know!

If you want an explanation of the changes, please take a look at the [upgrading documentation](https://github.com/Geal/nom/wiki/Upgrading-to-nom-1.0).

By the way, could you go to one (or all) of those links and write a few kind words about your experience writing parsers in Rust? It would really help me!
- [nom 1.0 release blogpost](https://www.clever-cloud.com/blog/engineering/2015/11/16/nom-1-0/)
- [Reddit post](https://www.reddit.com/r/rust/comments/3t10f3/nom_just_reached_10_cleaner_parsers_more_generic/)
- [Hacker News post](https://news.ycombinator.com/item?id=10574828)

Thank you for using nom!
